### PR TITLE
Correct date for TAGjam 16

### DIFF
--- a/jams/2014.json
+++ b/jams/2014.json
@@ -3,8 +3,8 @@
         {
             "name": "TAGjam 16",
             "url": "http://jams.gamejolt.io/tagjam16",
-            "start_date": "2014-10-07",
-            "end_date": "2014-10-10",
+            "start_date": "2014-11-07",
+            "end_date": "2014-11-10",
             "tags": [
                 "tagjam",
                 "arbitrary"


### PR DESCRIPTION
updating date which was wrong for TAGjam 16 (it is November but was added as October)
